### PR TITLE
Add Pointer Contracts to Assetlist

### DIFF
--- a/assetlist.json
+++ b/assetlist.json
@@ -124,7 +124,11 @@
       "images": {
         "svg": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/SEIYAN.svg"
       },
-      "type_asset": "cw20"
+      "type_asset": "cw20",
+      "pointer_contract": {
+        "address": "0x5f0E07dFeE5832Faa00c63F2D33A0D79150E8598",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "iSEI",
@@ -145,7 +149,11 @@
       "images": {
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/iSEI.png"
       },
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0x5Cf6826140C1C56Ff49C808A1A75407Cd1DF9423",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "SEA",
@@ -189,7 +197,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/USDCoin.png"
       },
       "coingecko_id": "axlusdc",
-      "type_asset": "ics20"
+      "type_asset": "ics20",
+      "pointer_contract": {
+        "address": "0xa855562b0644FaDFd8F04fC3e2eD0B69577EB816",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Osmosis",
@@ -212,7 +224,11 @@
         "svg": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/Osmosis.svg"
       },
       "coingecko_id": "osmosis",
-      "type_asset": "ics20"
+      "type_asset": "ics20",
+      "pointer_contract": {
+        "address": "0xBdE3bD155613752065C52059f8B2F72f506C4374",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Atom (Osmosis)",
@@ -235,7 +251,11 @@
         "svg": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/Atom.svg"
       },
       "coingecko_id": "cosmos",
-      "type_asset": "ics20"
+      "type_asset": "ics20",
+      "pointer_contract": {
+        "address": "0x0E8440025B74605151F5644b93AA861f35906Bec",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Atom",
@@ -258,7 +278,11 @@
         "svg": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/Atom.svg"
       },
       "coingecko_id": "cosmos",
-      "type_asset": "ics20"
+      "type_asset": "ics20",
+      "pointer_contract": {
+        "address": "0xaF5fd7Df92B103B40b9Ed8D0d002696a5436E4D8",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped Ether (Wormhole)",
@@ -280,7 +304,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/WrappedEther(Wormhole).png"
       },
       "coingecko_id": "weth",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0x4636DC75851c28561C4A117Be362Bedd7f9Ad8f8",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped USD Coin (Wormhole from Ethereum)",
@@ -303,7 +331,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/USDCoin.png"
       },
       "coingecko_id": "usd-coin",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0xa272ee55434655970f7226c95eF0068a22994B84",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped Tether USD (Wormhole from Ethereum)",
@@ -326,7 +358,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/USDT.png"
       },
       "coingecko_id": "tether",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0x3b5F977957CF3f62a9d357F302311e8B4ab8608a",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped BTC (Wormhole from Ethereum)",
@@ -349,7 +385,11 @@
         "svg": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/WrappedBTC(WormholefromEthereum).svg"
       },
       "coingecko_id": "bitcoin",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0xe369ddC65Ec947FCB10262AA0E08C3fB9823001a",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped USD Coin (Wormhole from Arbitrum)",
@@ -372,7 +412,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/USDCoin.png"
       },
       "coingecko_id": "usd-coin",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0xc60cb642EF30EbaF8D625E38BD73534913388da7",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped Ether (Wormhole from Arbitrum)",
@@ -394,7 +438,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/WrappedEther(Wormhole).png"
       },
       "coingecko_id": "weth",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0x28417c04dfB49Ec881051B8930d74f8C740Eb688",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped USD Coin (Wormhole from Polygon)",
@@ -417,7 +465,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/USDCoin.png"
       },
       "coingecko_id": "usd-coin",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0xA186cCd543732B1E6515e8f47AAAe989bA289665",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped USD Coin (Wormhole from Optimism)",
@@ -440,7 +492,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/USDCoin.png"
       },
       "coingecko_id": "usd-coin",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0x6EBC03CAb85815bc59a4286882c9Bad88a9A09fF",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped USD Coin (Wormhole from Solana)",
@@ -463,7 +519,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/USDCoin.png"
       },
       "coingecko_id": "usd-coin",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0x8eEDF32a4FC6fB78DDF231Cd3CcF6b7B8dF9D99d",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped USD Coin (Wormhole from BSC)",
@@ -486,7 +546,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/USDCoin.png"
       },
       "coingecko_id": "usd-coin",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0x2a5DC09df34c1276162b95415a38E5519E345c7F",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped Ether (Wormhole from BSC)",
@@ -508,7 +572,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/WrappedEther(Wormhole).png"
       },
       "coingecko_id": "weth",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0x9D128bE5d9C96A4A574A9bd277D7c18e331194bd",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "Wrapped USDT (Wormhole from BSC)",
@@ -531,7 +599,11 @@
         "png": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/USDT.png"
       },
       "coingecko_id": "tether",
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "pointer_contract": {
+        "address": "0xDA9edB031e3dEF95D0350366718e02a1216DB0ED",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "PKS",
@@ -552,7 +624,11 @@
       "images": {
         "svg": "https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/images/PKS.svg"
       },
-      "type_asset": "cw20"
+      "type_asset": "cw20",
+      "pointer_contract": {
+        "address": "0x24E4d0Af5a6b1C3BD336Dd60dEEfa64C704b19B7",
+        "type_asset": "erc20"
+      }
     },
     {
       "name": "USDT",


### PR DESCRIPTION
Add pointer contracts to assetlist. These pointer addresses were obtained by querying the chain registry using
seid q evm pointer <TYPE> <ADDRESS>